### PR TITLE
Undo unnecessary whitespace changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,7 @@
     <jdk.module.name>com.fasterxml.jackson.databind</jdk.module.name>
 
 
-    <!--  -->
-       <!-- These properties will be set by the Maven Dependency plugin -->
+    <!-- These properties will be set by the Maven Dependency plugin -->
     <annotatedJdk>${org.checkerframework:jdk8:jar}</annotatedJdk>
     <!-- Uncomment to use the Type Annotations compiler. -->
     <typeAnnotationsJavac>${org.checkerframework:compiler:jar}</typeAnnotationsJavac>
@@ -115,10 +114,6 @@
 
 
   </dependencies>
-
-
-
-  
 
   <build>
      <plugins>

--- a/src/main/java/com/fasterxml/jackson/databind/node/NullNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/NullNode.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import org.checkerframework.checker.nullness.qual.*;
 
+
 /**
  * This singleton value class is used to contain explicit JSON null
  * value.

--- a/src/main/java/com/fasterxml/jackson/databind/node/TreeTraversingParser.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/TreeTraversingParser.java
@@ -63,6 +63,7 @@ public class TreeTraversingParser extends ParserMinimalBase
     /* Life-cycle
     /**********************************************************
      */
+
     @SuppressWarnings("nullness")
     public TreeTraversingParser(JsonNode n) { this(n, null); }
 
@@ -102,6 +103,7 @@ public class TreeTraversingParser extends ParserMinimalBase
     /* Closeable implementation
     /**********************************************************
      */
+
     @SuppressWarnings("nullness")
     @Override
     public void close() throws IOException
@@ -118,6 +120,7 @@ public class TreeTraversingParser extends ParserMinimalBase
     /* Public API, traversal
     /**********************************************************
      */
+
     @SuppressWarnings("nullness")
     @Override
     public JsonToken nextToken() throws IOException, JsonParseException
@@ -188,6 +191,7 @@ public class TreeTraversingParser extends ParserMinimalBase
     /* Public API, token accessors
     /**********************************************************
      */
+
     @SuppressWarnings("nullness")
     @Override
     public String getCurrentName() {
@@ -223,6 +227,7 @@ public class TreeTraversingParser extends ParserMinimalBase
     /* Public API, access to textual content
     /**********************************************************
      */
+
     @SuppressWarnings("nullness")
     @Override
     public String getText()
@@ -278,6 +283,7 @@ public class TreeTraversingParser extends ParserMinimalBase
      */
 
     //public byte getByteValue() throws IOException, JsonParseException
+
     @SuppressWarnings("nullness")
     @Override
     public NumberType getNumberType() throws IOException, JsonParseException {
@@ -355,6 +361,7 @@ public class TreeTraversingParser extends ParserMinimalBase
     /* Public API, typed binary (base64) access
     /**********************************************************
      */
+
     @SuppressWarnings("nullness")
     @Override
     public byte[] getBinaryValue(Base64Variant b64variant)

--- a/src/main/java/com/fasterxml/jackson/databind/node/ValueNode.java
+++ b/src/main/java/com/fasterxml/jackson/databind/node/ValueNode.java
@@ -62,6 +62,7 @@ public abstract class ValueNode
      * Navigation methods
      **********************************************************************
      */
+
     @SuppressWarnings("nullness")
     @Override
     public final JsonNode get(int index) { return null; }
@@ -93,6 +94,7 @@ public abstract class ValueNode
      * Find methods: all "leaf" nodes return the same for these
      **********************************************************************
      */
+
     @SuppressWarnings("nullness")
     @Override
     public final JsonNode findValue(String fieldName) {


### PR DESCRIPTION
This reduces the diffs between the unannotated and annotated versions.